### PR TITLE
chore: fix unqualified image references

### DIFF
--- a/templates/basic/Dockerfile
+++ b/templates/basic/Dockerfile
@@ -1,12 +1,12 @@
 ARG GO_VERSION
 
-FROM golang:${GO_VERSION}-alpine3.17 as builder
+FROM docker.io/golang:${GO_VERSION}-alpine3.17 as builder
 RUN apk --no-cache add make bash
 WORKDIR /app  
 COPY . /app
 RUN make service
 
-FROM alpine:3.17.2
+FROM docker.io/alpine:3.17.2
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /app/cmd/{{.Name}}/{{.Name}} /usr/bin/{{.Name}}
 CMD ["{{.Name}}"]

--- a/templates/basic/Dockerfile.dev
+++ b/templates/basic/Dockerfile.dev
@@ -1,6 +1,6 @@
 ARG GO_VERSION
 
-FROM golang:${GO_VERSION}-bullseye
+FROM docker.io/golang:${GO_VERSION}-bullseye
 
 # Install necessary packages
 RUN apt-get update && \


### PR DESCRIPTION
Some tools like podman require extra configurations to set docker.io as default/unqualified reference. This is not safe and comes from a time were docker.io was one of the only options to host container images. Unqualified references may cause differente images to be downloaded on different hosts (depends on host configuration).