### PR TITLE
Use [[ and ]] as delims

### DIFF
--- a/gootstrap.go
+++ b/gootstrap.go
@@ -48,14 +48,9 @@ func generate(name, group string) {
 	}
 
 	applyTemplate := func(templ string) string {
-		// Why: some files, like Github CI files, have notation identical
-		// To Go templates. So for now we just try to apply the template and if it
-		// fails we assume it should be used as is (not the safest option, but no more time to deal
-		// with this right now).
-		t, err := template.New("templ").Parse(templ)
-		if err != nil {
-			return templ
-		}
+		// we use [[ and ]] because {{ and }} are also used by GitHub workflow definitions
+		t, err := template.New("templ").Delims("[[", "]]").Parse(templ)
+		assert(err)
 		result := bytes.Buffer{}
 		assert(t.Execute(&result, info))
 		return result.String()

--- a/templates/basic/.gitignore
+++ b/templates/basic/.gitignore
@@ -21,5 +21,5 @@
 go.work
 
 coverage.txt
-cmd/{{.Name}}/{{.Name}}
+cmd/[[.Name]]/[[.Name]]
 tmp/

--- a/templates/basic/Dockerfile
+++ b/templates/basic/Dockerfile
@@ -9,5 +9,5 @@ RUN make service
 
 FROM docker.io/alpine:${ALPINE_VERSION}
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /app/cmd/{{.Name}}/{{.Name}} /usr/bin/{{.Name}}
-CMD ["{{.Name}}"]
+COPY --from=builder /app/cmd/[[.Name]]/[[.Name]] /usr/bin/[[.Name]]
+CMD ["[[.Name]]"]

--- a/templates/basic/Makefile
+++ b/templates/basic/Makefile
@@ -7,9 +7,9 @@ ALPINE_VERSION=3.19
 
 # configuration/aliases
 version=$(shell git rev-parse --short HEAD)
-base_image=us-central1-docker.pkg.dev/birdie-org/birdie/{{.Group}}/{{.Name}}
+base_image=us-central1-docker.pkg.dev/birdie-org/birdie/[[.Group]]/[[.Name]]
 image=$(base_image):$(version)
-devimage={{.Name}}-dev
+devimage=[[.Name]]-dev
 # To avoid downloading deps everytime it runs on containers
 gopkg=$(devimage)-gopkg
 gocache=$(devimage)-gocache
@@ -36,12 +36,12 @@ fmt:
 ## builds the service
 .PHONY: service
 service:
-	go build -o ./cmd/{{.Name}}/{{.Name}} ./cmd/{{.Name}}
+	go build -o ./cmd/[[.Name]]/[[.Name]] ./cmd/[[.Name]]
 
 ## runs the service locally
 .PHONY: run
 run: service
-	./cmd/{{.Name}}/{{.Name}}
+	./cmd/[[.Name]]/[[.Name]]
 
 ## tidy up go modules
 .PHONY: mod
@@ -71,7 +71,7 @@ test/coverage/show: test/coverage
 ## Configure a proxy to the service running on GKE (environment depends on which cluster is configured on kubectl).
 .PHONY: port-forward
 port-forward:
-	kubectl port-forward -n enrichment service/{{.Name}} 8080:80
+	kubectl port-forward -n enrichment service/[[.Name]] 8080:80
 
 ## Build the service image
 .PHONY: image

--- a/templates/basic/cmd/[[.Name]]/main.go.template
+++ b/templates/basic/cmd/[[.Name]]/main.go.template
@@ -1,7 +1,7 @@
-// {{.Name}} runs the service.
+// [[.Name]] runs the service.
 // For details on how to configure it just run:
 //
-//	{{.Name}} --help
+//	[[.Name]] --help
 package main
 
 import (
@@ -11,13 +11,13 @@ import (
 )
 
 func main() {
-	logcfg, err := slog.LoadConfig("{{.ConfigPrefix}}")
+	logcfg, err := slog.LoadConfig("[[.ConfigPrefix]]")
 	abortonerr(err)
 
 	err = slog.Configure(logcfg)
 	abortonerr(err)
 
-	slog.Info("TODO: implement {{.Name}}")
+	slog.Info("TODO: implement [[.Name]]")
 }
 
 func abortonerr(err error) {

--- a/templates/basic/go.mod.template
+++ b/templates/basic/go.mod.template
@@ -1,4 +1,4 @@
-module github.com/birdie-ai/{{.Name}}
+module github.com/birdie-ai/[[.Name]]
 
 go 1.21
 


### PR DESCRIPTION
By default, Go templates use `{{` and `}}` to mark up the dynamic parts of a template. This creates trouble with GitHub Actions definitions, which also use `{{` and `}}`. In the future, we may have the same problem with justfiles. This PR changes the delimiters to `[[` and `]]` to avoid that issue.